### PR TITLE
Complete iOS dashboard with last upload time

### DIFF
--- a/ios/OSRP/OSRP/ViewModels/StatusViewModel.swift
+++ b/ios/OSRP/OSRP/ViewModels/StatusViewModel.swift
@@ -15,9 +15,11 @@ class StatusViewModel: ObservableObject {
     @Published var isCollecting: Bool = false
     @Published var isUploadRunning: Bool = false
     @Published var pendingRecords: Int = 0
+    @Published var lastUploadTime: Date? = nil
 
     private let dataService = DataService()
     private let uploadService = UploadService()
+    private let preferences = PreferencesManager.shared
     private var refreshTask: Task<Void, Never>?
 
     init() {
@@ -60,6 +62,9 @@ class StatusViewModel: ObservableObject {
 
         // Get pending records count
         pendingRecords = await dataService.getPendingRecordsCount()
+
+        // Get last upload time
+        lastUploadTime = preferences.lastUploadTime
     }
 
     /// Start data collection

--- a/ios/OSRP/OSRP/Views/MainView.swift
+++ b/ios/OSRP/OSRP/Views/MainView.swift
@@ -115,6 +115,37 @@ struct MainView: View {
                     .shadow(radius: 2)
                     .padding(.horizontal)
 
+                    // Last Upload Card
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Last Upload")
+                            .font(.headline)
+
+                        if let lastUpload = statusViewModel.lastUploadTime {
+                            Text(lastUpload, style: .relative)
+                                .font(.body)
+                                .foregroundColor(.secondary)
+
+                            Text(lastUpload, style: .date)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 4)
+
+                            Text(lastUpload, style: .time)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("Never uploaded")
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.systemBackground))
+                    .cornerRadius(12)
+                    .shadow(radius: 2)
+                    .padding(.horizontal)
+
                     // Control Buttons
                     VStack(spacing: 12) {
                         if statusViewModel.isCollecting {


### PR DESCRIPTION
Completes Issue #21 by adding the missing last upload time display.

## Changes

- **StatusViewModel**: Added  property loaded from PreferencesManager
- **MainView**: Added Last Upload card with relative time, date, and time display

## Issue #21 Acceptance Criteria

All requirements now met:
- ✅ UI implemented in SwiftUI  
- ✅ Shows realtime status (auto-refresh every 5 seconds)
- ✅ Clean and responsive design
- ✅ Login screen (created in Issue #17)
- ✅ Dashboard showing:
  - ✅ Connection status
  - ✅ Data collection status
  - ✅ Last upload time (added in this PR)
  - ✅ Records pending upload
  - ✅ HealthKit permission status

Fixes #21